### PR TITLE
Soporte de múltiples cuentas por usuario

### DIFF
--- a/src/backend/Cliente.ts
+++ b/src/backend/Cliente.ts
@@ -1,6 +1,11 @@
-import type { UserData, Usuario } from "@/lib/core";
+import type { Cuenta, UserData, Usuario } from "@/lib/core";
+import {
+  consignar as consignarCore,
+  obtenerCuenta as obtenerCuentaCore,
+  registrarUsuario,
+  retirar as retirarCore,
+} from "@/lib/core";
 import { readDb, writeDb } from "@/lib/database";
-import { registrarUsuario } from "@/lib/core";
 
 interface ICliente {
   nombre: string;
@@ -9,19 +14,25 @@ interface ICliente {
   documento: string;
   direccion: string;
   contrasena: string;
-  saldo: number;
-  historial: string[];
+  celular?: string;
+  email?: string;
+  cuentas?: Cuenta[];
+  intentosFallidos?: number;
+  bloqueado?: boolean;
 }
 
+const crearCuenta = (documento: string, tipo: "ahorros" | "corriente"): Cuenta => ({
+  id: `${documento}-${tipo}`,
+  tipo,
+  saldo: 0,
+  movimientos: [],
+});
+
 export class Cliente {
-  private nombre: string;
+  private data: Usuario;
   private apellido: string;
   private userName: string;
-  private documento: string;
   private direccion: string;
-  private contrasena: string;
-  private saldo: number;
-  private historial: string[];
 
   constructor({
     nombre,
@@ -30,127 +41,217 @@ export class Cliente {
     documento,
     direccion,
     contrasena,
-    saldo = 0,
+    celular = "",
+    email = "",
+    cuentas,
+    intentosFallidos = 0,
+    bloqueado = false,
   }: ICliente) {
-    this.nombre = nombre;
     this.apellido = apellido;
-    this.documento = documento;
-    this.direccion = direccion;
-    this.contrasena = contrasena;
-    this.saldo = saldo;
     this.userName = usuario;
-    this.historial = [];
+    this.direccion = direccion;
+
+    const cuentasIniciales =
+      cuentas && cuentas.length > 0
+        ? cuentas
+        : [crearCuenta(documento, "ahorros"), crearCuenta(documento, "corriente")];
+
+    this.data = {
+      id: documento,
+      nombre,
+      cedula: documento,
+      celular,
+      email,
+      password: contrasena,
+      cuentas: cuentasIniciales.map((cuenta) => ({
+        ...cuenta,
+        movimientos: [...cuenta.movimientos],
+      })),
+      intentosFallidos,
+      bloqueado,
+    };
   }
 
-  /* movimiento(descripcion: string, monto: number, idUser: string) {
-    const fecha = new Date().toLocaleString();
-    this.historial.push(`[${fecha}] ${descripcion}`);
-    agregarMovimiento(this as unknown as Usuario, "retiro", monto);
-    const usuarios = readDb();
-    const usuario = usuarios[idUser];
-    if (usuario) {
-      agregarMovimiento(usuario, "consignacion", monto);
+  private clonarUsuario(usuario: Usuario): Usuario {
+    return {
+      ...usuario,
+      cuentas: usuario.cuentas.map((cuenta) => ({
+        ...cuenta,
+        movimientos: [...cuenta.movimientos],
+      })),
+    };
+  }
+
+  private normalizarCuentaId(cuentaId: string): string {
+    if (this.data.cuentas.some((cuenta) => cuenta.id === cuentaId)) {
+      return cuentaId;
     }
-  } */
 
-  consultarSaldo() {
-    return `El saldo de ${this.nombre} es $${this.saldo}`;
+    const porTipo = this.data.cuentas.find((cuenta) => cuenta.tipo === cuentaId);
+    if (porTipo) {
+      return porTipo.id;
+    }
+
+    const compuesto = `${this.data.id}-${cuentaId}`;
+    if (this.data.cuentas.some((cuenta) => cuenta.id === compuesto)) {
+      return compuesto;
+    }
+
+    return cuentaId;
   }
 
-  consignaciones(monto: number, idUser: string) {
-    if (monto > 0) {
-      this.saldo += monto;
-      this.movimientoV2("consignacion", monto, idUser);
-      this.guardar();
-      return `Consignacion exitosa. Nuevo saldo $${this.saldo}`;
-    } else {
+  private obtenerCuentaLocal(cuentaId: string = "ahorros"): Cuenta {
+    const idNormalizado = this.normalizarCuentaId(cuentaId);
+    const cuenta =
+      this.data.cuentas.find((c) => c.id === idNormalizado) ??
+      this.data.cuentas.find((c) => c.tipo === cuentaId) ??
+      this.data.cuentas[0];
+
+    if (!cuenta) {
+      throw new Error(`Cuenta ${cuentaId} no encontrada`);
+    }
+
+    return cuenta;
+  }
+
+  private sincronizar(usuario: Usuario) {
+    this.data = this.clonarUsuario(usuario);
+  }
+
+  public actualizarInstancia(usuario: Usuario) {
+    this.sincronizar(usuario);
+  }
+
+  get id() {
+    return this.data.id;
+  }
+
+  get nombre() {
+    return this.data.nombre;
+  }
+
+  consultarSaldo(cuentaId: string = "ahorros") {
+    const cuenta = this.obtenerCuentaLocal(cuentaId);
+    return `El saldo de ${this.data.nombre} en ${cuenta.tipo} es $${cuenta.saldo}`;
+  }
+
+  consignaciones(
+    monto: number,
+    idUser: string = this.data.id,
+    cuentaId: string = "ahorros"
+  ) {
+    if (monto <= 0) {
       return `El monto debe ser mayor a 0`;
     }
+
+    const usuarios = readDb();
+    const usuario = usuarios[idUser];
+    if (!usuario) {
+      return `Usuario no encontrado`;
+    }
+
+    const resultado = consignarCore(usuario, monto, cuentaId);
+    if (!resultado.success || !resultado.usuario || !resultado.cuenta) {
+      return resultado.message ?? `No fue posible registrar la consignación`;
+    }
+
+    if (idUser === this.data.id) {
+      this.sincronizar(resultado.usuario);
+    }
+
+    return `Consignacion exitosa. Nuevo saldo en ${resultado.cuenta.tipo} $${resultado.cuenta.saldo}`;
   }
 
-  retiros(retiro: number) {
-    if (retiro > 0 && retiro <= this.saldo) {
-      this.saldo -= retiro;
-      this.movimientoV2("retiro", retiro, this.documento);
-      this.guardar();
-      return `Retiro exitoso. Saldo actual $${this.saldo}`;
-    } else {
+  retiros(retiro: number, cuentaId: string = "ahorros") {
+    if (retiro <= 0) {
       return `Revise monto a retirar. Monto a retirar debe ser mayor a 0 y no puede ser mayor al saldo`;
     }
-  }
 
-  consultarMovimientos() {
-    if (this.historial.length === 0) {
-      return `${this.nombre} no tiene movimientos registrados`;
+    const usuarios = readDb();
+    const usuario = usuarios[this.data.id];
+    if (!usuario) {
+      return `Usuario no encontrado`;
     }
-    return `historial de movimientos ${this.nombre}: \n${this.historial.join(
-      "\n"
-    )}`;
+
+    const resultado = retirarCore(usuario, retiro, cuentaId);
+    if (!resultado.success || !resultado.usuario || !resultado.cuenta) {
+      return resultado.message ?? `No fue posible registrar el retiro`;
+    }
+
+    this.sincronizar(resultado.usuario);
+    return `Retiro exitoso. Saldo actual en ${resultado.cuenta.tipo} $${resultado.cuenta.saldo}`;
   }
 
-  transferencias(monto: number, cliente: Cliente) {
+  consultarMovimientos(cuentaId: string = "ahorros") {
+    const cuenta = this.obtenerCuentaLocal(cuentaId);
+    if (cuenta.movimientos.length === 0) {
+      return `${this.data.nombre} no tiene movimientos registrados en ${cuenta.tipo}`;
+    }
+
+    const historial = cuenta.movimientos
+      .map(
+        (mov) =>
+          `${mov.fecha} - ${mov.tipo}: $${mov.monto.toLocaleString()} (Saldo: $${mov.saldoNuevo.toLocaleString()})`
+      )
+      .join("\n");
+
+    return `historial de movimientos ${this.data.nombre} (${cuenta.tipo}): \n${historial}`;
+  }
+
+  transferencias(
+    monto: number,
+    cliente: Cliente,
+    cuentaOrigen: string = "ahorros",
+    cuentaDestino: string = "ahorros"
+  ) {
     if (monto <= 0) {
       return `Debe ser mayor a 0`;
     }
-    if (monto > this.saldo) {
+
+    const usuarios = readDb();
+    const origen = usuarios[this.data.id];
+    if (!origen) {
+      return `Usuario no encontrado`;
+    }
+
+    const cuentaOrigenDb = obtenerCuentaCore(origen, cuentaOrigen);
+    if (!cuentaOrigenDb || monto > cuentaOrigenDb.saldo) {
       return `Fondos insuficientes`;
     }
-    this.saldo -= monto;
-    cliente.saldo += monto;
-    this.movimientoV2("retiro", monto, this.documento);
-    cliente.movimientoV2("consignacion", monto, this.documento);
-    this.guardar();
-    cliente.guardar();
+
+    const resultadoRetiro = retirarCore(origen, monto, cuentaOrigen);
+    if (!resultadoRetiro.success || !resultadoRetiro.usuario || !resultadoRetiro.cuenta) {
+      return resultadoRetiro.message ?? `No fue posible realizar la transferencia`;
+    }
+
+    const usuariosActualizados = readDb();
+    const destinoUsuario = usuariosActualizados[cliente.id];
+    if (!destinoUsuario) {
+      return `Cliente destino no encontrado`;
+    }
+
+    const resultadoConsignacion = consignarCore(destinoUsuario, monto, cuentaDestino);
+    if (!resultadoConsignacion.success || !resultadoConsignacion.usuario || !resultadoConsignacion.cuenta) {
+      return resultadoConsignacion.message ?? `No fue posible realizar la transferencia`;
+    }
+
+    this.sincronizar(resultadoRetiro.usuario);
+    cliente.actualizarInstancia(resultadoConsignacion.usuario);
+
     console.log(
-      `Transferencia de $${monto} a ${cliente.nombre} exitosa. Nuevo saldo: $${this.saldo}`
+      `Transferencia de $${monto} a ${cliente.nombre} exitosa. Nuevo saldo: $${resultadoRetiro.cuenta.saldo}`
     );
-  }
-
-  movimientoV2(tipo: "retiro" | "consignacion", monto: number, idUser: string) {
-    const usuario = readDb()[idUser];
-    if (!usuario) return;
-
-    const movimiento = {
-      id: Date.now(),
-      tipo,
-      monto,
-      fecha: new Date().toLocaleString(),
-    };
-
-    const usuarioActualizado = {
-      ...usuario,
-      saldo:
-        tipo === "retiro"
-          ? usuario.saldo - movimiento.monto
-          : usuario.saldo + movimiento.monto,
-      movimientos: [...usuario.movimientos, movimiento],
-    };
   }
 
   guardar() {
     const usuarios = readDb();
-    usuarios[this.documento] = {
-      ...(this as unknown as Usuario),
-    };
+    usuarios[this.data.id] = this.clonarUsuario(this.data);
     writeDb(usuarios);
     return true;
   }
 
   registrarUsuario(datos: UserData): boolean {
-    const usuarios = readDb();
-    if (usuarios[datos.cedula]) {
-      return false; // Usuario ya existe
-    }
-    const usuario = this.createUser(
-      datos.nombre,
-      datos.cedula,
-      datos.celular,
-      datos.email,
-      datos.password
-    );
-    usuarios[datos.cedula] = usuario;
-    writeDb(usuarios);
-    return true;
+    return registrarUsuario(datos);
   }
 
   createUser(
@@ -160,6 +261,7 @@ export class Cliente {
     email: string,
     password: string
   ): Usuario {
+    const cuentas = [crearCuenta(cedula, "ahorros"), crearCuenta(cedula, "corriente")];
     return {
       id: cedula,
       nombre,
@@ -167,29 +269,31 @@ export class Cliente {
       celular,
       email,
       password,
-      saldo: 0,
-      movimientos: [],
+      cuentas,
       intentosFallidos: 0,
       bloqueado: false,
     };
   }
 
-  static cargar(usuario: string): Cliente | null {
-    const data = localStorage.getItem(usuario);
-    if (data) {
-      const obj = JSON.parse(data);
-      const cliente = new Cliente({
-        nombre: obj.nombre,
-        apellido: obj.apellido,
-        documento: obj.documento,
-        direccion: obj.direccion,
-        usuario: obj.usuario,
-        contrasena: obj.contrasena,
-        saldo: obj.saldo,
-      } as ICliente);
-      cliente.historial = obj.historial;
-      return cliente;
+  static cargar(documento: string): Cliente | null {
+    const usuarios = readDb();
+    const data = usuarios[documento];
+    if (!data) {
+      return null;
     }
-    return null;
+
+    return new Cliente({
+      nombre: data.nombre,
+      apellido: "",
+      usuario: documento,
+      documento: data.cedula,
+      direccion: "",
+      contrasena: data.password,
+      celular: data.celular,
+      email: data.email,
+      cuentas: data.cuentas,
+      intentosFallidos: data.intentosFallidos,
+      bloqueado: data.bloqueado,
+    });
   }
 }

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,16 +1,3 @@
-type Usuario = {
-  id: string;
-  nombre: string;
-  cedula: string;
-  celular: string;
-  email: string;
-  password: string;
-  saldo: number;
-  movimientos: Movimiento[];
-  intentosFallidos: number;
-  bloqueado: boolean;
-};
-
 type Movimiento = {
   id: number;
   tipo: "retiro" | "consignación" | string;
@@ -20,15 +7,113 @@ type Movimiento = {
   saldoNuevo: number;
 };
 
+type Cuenta = {
+  id: string;
+  tipo: "ahorros" | "corriente" | string;
+  saldo: number;
+  movimientos: Movimiento[];
+};
+
+type Usuario = {
+  id: string;
+  nombre: string;
+  cedula: string;
+  celular: string;
+  email: string;
+  password: string;
+  cuentas: Cuenta[];
+  intentosFallidos: number;
+  bloqueado: boolean;
+};
+
 type Database = {
   [key: string]: Usuario;
 };
 
+const createCuenta = (
+  cedula: string,
+  tipo: "ahorros" | "corriente"
+): Cuenta => ({
+  id: `${cedula}-${tipo}`,
+  tipo,
+  saldo: 0,
+  movimientos: [],
+});
+
+const migrateUsuario = (
+  entrada: Usuario | (Usuario & { saldo?: number; movimientos?: Movimiento[] })
+): Usuario => {
+  const { cedula } = entrada;
+
+  if (Array.isArray((entrada as Usuario).cuentas)) {
+    const cuentas = (entrada as Usuario).cuentas.map((cuenta) => ({
+      ...cuenta,
+      id: cuenta.id ?? `${cedula}-${cuenta.tipo}`,
+      movimientos: Array.isArray(cuenta.movimientos) ? cuenta.movimientos : [],
+      saldo: typeof cuenta.saldo === "number" ? cuenta.saldo : 0,
+    }));
+
+    const cuentasPorTipo = new Map<string, Cuenta>();
+    cuentas.forEach((cuenta) => {
+      cuentasPorTipo.set(cuenta.tipo, cuenta);
+    });
+
+    ["ahorros", "corriente"].forEach((tipo) => {
+      if (!cuentasPorTipo.has(tipo)) {
+        cuentasPorTipo.set(tipo, createCuenta(cedula, tipo as "ahorros" | "corriente"));
+      }
+    });
+
+    return {
+      ...entrada,
+      cuentas: Array.from(cuentasPorTipo.values()),
+    } as Usuario;
+  }
+
+  const saldo = typeof (entrada as { saldo?: number }).saldo === "number" ? (entrada as { saldo: number }).saldo : 0;
+  const movimientos = Array.isArray((entrada as { movimientos?: Movimiento[] }).movimientos)
+    ? ((entrada as { movimientos: Movimiento[] }).movimientos ?? [])
+    : [];
+
+  const cuentaAhorros = {
+    id: `${cedula}-ahorros`,
+    tipo: "ahorros",
+    saldo,
+    movimientos,
+  };
+
+  const cuentaCorriente = createCuenta(cedula, "corriente");
+
+  const { saldo: _saldo, movimientos: _movimientos, ...resto } = entrada as Usuario & {
+    saldo?: number;
+    movimientos?: Movimiento[];
+  };
+
+  return {
+    ...resto,
+    cuentas: [cuentaAhorros, cuentaCorriente],
+  };
+};
+
 export const readDb = (): Database => {
   const data = localStorage.getItem("usuarios");
-  return data ? JSON.parse(data) : {};
+  if (!data) {
+    return {};
+  }
+
+  const parsed = JSON.parse(data) as Database;
+
+  return Object.entries(parsed).reduce<Database>((acc, [key, usuario]) => {
+    acc[key] = migrateUsuario(usuario);
+    return acc;
+  }, {} as Database);
 };
 
 export const writeDb = (data: Database) => {
-  localStorage.setItem("usuarios", JSON.stringify(data));
+  const serializable = Object.entries(data).reduce<Database>((acc, [key, usuario]) => {
+    acc[key] = migrateUsuario(usuario);
+    return acc;
+  }, {} as Database);
+
+  localStorage.setItem("usuarios", JSON.stringify(serializable));
 };


### PR DESCRIPTION
## Summary
- refactor core banking types to include cuentas por usuario y actualizar operaciones para trabajar por cuenta
- migrar la persistencia en localStorage serializando y migrando cuentas en lugar de saldo/movimientos planos
- actualizar Cliente, la consola y la UI principal para usar las nuevas cuentas y mensajes asociados

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e0894ffbcc83309a8140187dd737cd