### PR TITLE
Implement multi-account handling across the app

### DIFF
--- a/src/backend/Cliente.ts
+++ b/src/backend/Cliente.ts
@@ -13,6 +13,21 @@ interface ICliente {
   historial: string[];
 }
 
+const createDefaultAccounts = (): Usuario["cuentas"] => ({
+  ahorros: {
+    id: "ahorros",
+    nombre: "Cuenta de ahorros",
+    saldo: 0,
+    movimientos: [],
+  },
+  corriente: {
+    id: "corriente",
+    nombre: "Cuenta corriente",
+    saldo: 0,
+    movimientos: [],
+  },
+});
+
 export class Cliente {
   private nombre: string;
   private apellido: string;
@@ -22,6 +37,7 @@ export class Cliente {
   private contrasena: string;
   private saldo: number;
   private historial: string[];
+  private cuentas: Usuario["cuentas"];
 
   constructor({
     nombre,
@@ -40,6 +56,7 @@ export class Cliente {
     this.saldo = saldo;
     this.userName = usuario;
     this.historial = [];
+    this.cuentas = createDefaultAccounts();
   }
 
   /* movimiento(descripcion: string, monto: number, idUser: string) {
@@ -169,6 +186,7 @@ export class Cliente {
       password,
       saldo: 0,
       movimientos: [],
+      cuentas: createDefaultAccounts(),
       intentosFallidos: 0,
       bloqueado: false,
     };

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -1,13 +1,23 @@
 import { readDb, writeDb } from "./database";
 
 // Interfaces
-type Movimiento = {
+export type TipoCuenta = "ahorros" | "corriente";
+
+export type Movimiento = {
   id: number;
-  tipo: "retiro" | "consignación" | string;
+  tipo: "retiro" | "consignacion" | string;
   monto: number;
   fecha: string;
   saldoAnterior: number;
   saldoNuevo: number;
+  cuenta: TipoCuenta;
+};
+
+export type Cuenta = {
+  id: TipoCuenta;
+  nombre: string;
+  saldo: number;
+  movimientos: Movimiento[];
 };
 
 export type Usuario = {
@@ -19,16 +29,21 @@ export type Usuario = {
   password: string;
   saldo: number;
   movimientos: Movimiento[];
+  cuentas: Record<TipoCuenta, Cuenta>;
   intentosFallidos: number;
   bloqueado: boolean;
 };
 
+type UsuarioPersistido = Omit<Usuario, "cuentas" | "movimientos" | "saldo"> & {
+  cuentas?: Record<TipoCuenta, Partial<Cuenta>>;
+  movimientos?: Array<Movimiento | (Movimiento & { cuenta?: TipoCuenta })>;
+  saldo?: number;
+};
+
 export type UserData = Omit<
   Usuario,
-  "id" | "saldo" | "movimientos" | "intentosFallidos" | "bloqueado"
-> & {
-  password: string;
-};
+  "id" | "saldo" | "movimientos" | "intentosFallidos" | "bloqueado" | "cuentas"
+>;
 
 type LoginResponse = {
   success: boolean;
@@ -37,6 +52,71 @@ type LoginResponse = {
 };
 
 // Estructura de datos del usuario
+const createDefaultAccounts = (): Record<TipoCuenta, Cuenta> => ({
+  ahorros: {
+    id: "ahorros",
+    nombre: "Cuenta de ahorros",
+    saldo: 0,
+    movimientos: [],
+  },
+  corriente: {
+    id: "corriente",
+    nombre: "Cuenta corriente",
+    saldo: 0,
+    movimientos: [],
+  },
+});
+
+const normalizarMovimiento = (
+  movimiento: Movimiento | (Movimiento & { cuenta?: TipoCuenta })
+): Movimiento => ({
+  ...movimiento,
+  cuenta: movimiento.cuenta ?? "ahorros",
+});
+
+const normalizarCuenta = (
+  cuenta: Partial<Cuenta> | undefined,
+  id: TipoCuenta
+): Cuenta => ({
+  id,
+  nombre:
+    cuenta?.nombre ?? (id === "ahorros" ? "Cuenta de ahorros" : "Cuenta corriente"),
+  saldo: cuenta?.saldo ?? 0,
+  movimientos: (cuenta?.movimientos ?? []).map(normalizarMovimiento),
+});
+
+const calcularSaldoTotal = (cuentas: Record<TipoCuenta, Cuenta>): number =>
+  Object.values(cuentas).reduce((total, cuenta) => total + cuenta.saldo, 0);
+
+const normalizarUsuario = (usuario: UsuarioPersistido): Usuario => {
+  const cuentasBase = usuario.cuentas ?? createDefaultAccounts();
+  const cuentas: Record<TipoCuenta, Cuenta> = {
+    ahorros: normalizarCuenta(cuentasBase.ahorros, "ahorros"),
+    corriente: normalizarCuenta(cuentasBase.corriente, "corriente"),
+  };
+
+  // Migración para usuarios sin estructura de cuentas
+  if (!usuario.cuentas) {
+    cuentas.ahorros = {
+      ...cuentas.ahorros,
+      saldo: usuario.saldo ?? 0,
+      movimientos:
+        usuario.movimientos?.map(normalizarMovimiento) ?? cuentas.ahorros.movimientos,
+    };
+  }
+
+  const movimientosGlobales = usuario.movimientos?.length
+    ? usuario.movimientos.map(normalizarMovimiento)
+    : [...cuentas.ahorros.movimientos, ...cuentas.corriente.movimientos];
+
+  return {
+    ...usuario,
+    cuentas,
+    saldo: calcularSaldoTotal(cuentas),
+    movimientos: movimientosGlobales,
+  };
+};
+
 const createUser = (
   nombre: string,
   cedula: string,
@@ -52,6 +132,7 @@ const createUser = (
   password,
   saldo: 0,
   movimientos: [],
+  cuentas: createDefaultAccounts(),
   intentosFallidos: 0,
   bloqueado: false,
 });
@@ -82,8 +163,9 @@ export const iniciarSesion = (id: string, password: string): LoginResponse => {
     return { success: false, message: "Cuenta bloqueada por 24 horas" };
 
   if (usuario.password === password) {
+    const usuarioNormalizado = normalizarUsuario(usuario);
     const usuarioActualizado = {
-      ...usuario,
+      ...usuarioNormalizado,
       intentosFallidos: 0,
       bloqueado: false,
     };
@@ -142,10 +224,10 @@ export const actualizarPerfil = (
     return { success: false, message: "Usuario no encontrado" };
   }
 
-  const actualizado: Usuario = {
+  const actualizado = normalizarUsuario({
     ...actual,
     ...cambios,
-  };
+  });
 
   usuarios[usuario.id] = actualizado;
   writeDb(usuarios);
@@ -156,21 +238,39 @@ export const actualizarPerfil = (
 const agregarMovimiento = (
   usuario: Usuario,
   tipo: "retiro" | "consignacion",
-  monto: number
+  monto: number,
+  cuentaId: TipoCuenta
 ): Usuario => {
-  const movimiento = {
+  const cuenta = usuario.cuentas[cuentaId];
+  if (!cuenta) {
+    return usuario;
+  }
+
+  const movimiento: Movimiento = {
     id: Date.now(),
     tipo,
     monto,
     fecha: new Date().toLocaleString(),
-    saldoAnterior: usuario.saldo,
-    saldoNuevo:
-      tipo === "retiro" ? usuario.saldo - monto : usuario.saldo + monto,
+    saldoAnterior: cuenta.saldo,
+    saldoNuevo: tipo === "retiro" ? cuenta.saldo - monto : cuenta.saldo + monto,
+    cuenta: cuentaId,
   };
 
-  const usuarioActualizado = {
-    ...usuario,
+  const cuentaActualizada: Cuenta = {
+    ...cuenta,
     saldo: movimiento.saldoNuevo,
+    movimientos: [...cuenta.movimientos, movimiento],
+  };
+
+  const cuentasActualizadas: Record<TipoCuenta, Cuenta> = {
+    ...usuario.cuentas,
+    [cuentaId]: cuentaActualizada,
+  };
+
+  const usuarioActualizado: Usuario = {
+    ...usuario,
+    cuentas: cuentasActualizadas,
+    saldo: calcularSaldoTotal(cuentasActualizadas),
     movimientos: [...usuario.movimientos, movimiento],
   };
 
@@ -178,29 +278,105 @@ const agregarMovimiento = (
   return usuarioActualizado;
 };
 
-export const retirar = (usuario: Usuario, monto: number) => {
+export const retirar = (usuario: Usuario, monto: number, cuentaId: TipoCuenta) => {
   if (monto <= 0) {
     return { success: false, message: "El monto debe ser mayor a 0" };
   }
-  if (monto > usuario.saldo) {
+
+  const cuenta = usuario.cuentas[cuentaId];
+  if (!cuenta) {
+    return { success: false, message: "Cuenta no encontrada" };
+  }
+
+  if (monto > cuenta.saldo) {
     return { success: false, message: "Saldo insuficiente" };
   }
-  const usuarioActualizado = agregarMovimiento(usuario, "retiro", monto);
+
+  const usuarioActualizado = agregarMovimiento(usuario, "retiro", monto, cuentaId);
+  const cuentaActualizada = usuarioActualizado.cuentas[cuentaId];
   return {
     success: true,
-    message: `Retiro exitoso. Saldo actual: $${usuarioActualizado.saldo.toLocaleString()}`,
+    message: `Retiro exitoso. Saldo actual en ${cuentaActualizada.nombre}: $${cuentaActualizada.saldo.toLocaleString()}`,
     usuario: usuarioActualizado,
   };
 };
 
-export const consignar = (usuario: Usuario, monto: number) => {
+export const obtenerUsuarioPorId = (id: string): Usuario | null => {
+  const usuario = readDb()[id];
+  if (!usuario) {
+    return null;
+  }
+  return normalizarUsuario(usuario);
+};
+
+export const consignar = (
+  usuario: Usuario,
+  monto: number,
+  cuentaOrigen: TipoCuenta,
+  destinatarioId?: string,
+  cuentaDestino?: TipoCuenta
+) => {
   if (monto <= 0) {
     return { success: false, message: "El monto debe ser mayor a 0" };
   }
-  const usuarioActualizado = agregarMovimiento(usuario, "consignacion", monto);
+
+  const cuentaOrigenData = usuario.cuentas[cuentaOrigen];
+  if (!cuentaOrigenData) {
+    return { success: false, message: "Cuenta origen no válida" };
+  }
+
+  const destinatarioNormalizado =
+    destinatarioId && destinatarioId !== usuario.id
+      ? obtenerUsuarioPorId(destinatarioId)
+      : null;
+
+  if (destinatarioId && destinatarioId !== usuario.id && !destinatarioNormalizado) {
+    return { success: false, message: "Destinatario no encontrado" };
+  }
+
+  const cuentaDestinoId: TipoCuenta = destinatarioNormalizado
+    ? cuentaDestino ?? "ahorros"
+    : cuentaDestino ?? cuentaOrigen;
+
+  if (destinatarioNormalizado) {
+    const cuentaDestinoData = destinatarioNormalizado.cuentas[cuentaDestinoId];
+    if (!cuentaDestinoData) {
+      return { success: false, message: "Cuenta destino no válida" };
+    }
+
+    if (monto > cuentaOrigenData.saldo) {
+      return { success: false, message: "Saldo insuficiente" };
+    }
+
+    const usuarioActualizado = agregarMovimiento(
+      usuario,
+      "retiro",
+      monto,
+      cuentaOrigen
+    );
+
+    agregarMovimiento(destinatarioNormalizado, "consignacion", monto, cuentaDestinoId);
+
+    const cuentaOrigenActualizada = usuarioActualizado.cuentas[cuentaOrigen];
+
+    return {
+      success: true,
+      message: `Consignación realizada a ${destinatarioNormalizado.nombre}. Saldo actual en ${cuentaOrigenActualizada.nombre}: $${cuentaOrigenActualizada.saldo.toLocaleString()}`,
+      usuario: usuarioActualizado,
+    };
+  }
+
+  const usuarioActualizado = agregarMovimiento(
+    usuario,
+    "consignacion",
+    monto,
+    cuentaDestinoId
+  );
+  const cuentaDestinoActualizada = usuarioActualizado.cuentas[cuentaDestinoId];
+
   return {
     success: true,
-    message: `Consignación exitosa. Saldo actual: $${usuarioActualizado.saldo.toLocaleString()}`,
+    message: `Consignación exitosa. Saldo actual en ${cuentaDestinoActualizada.nombre}: $${cuentaDestinoActualizada.saldo.toLocaleString()}`,
     usuario: usuarioActualizado,
   };
 };
@@ -219,7 +395,10 @@ export const cambiarPassword = (
       message: "La nueva contraseña debe tener al menos 4 caracteres",
     };
   }
-  const usuarioActualizado = { ...usuario, password: passwordNuevo };
+  const usuarioActualizado = normalizarUsuario({
+    ...usuario,
+    password: passwordNuevo,
+  });
   actualizarUsuario(usuarioActualizado);
   return {
     success: true,

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,3 +1,22 @@
+type TipoCuenta = "ahorros" | "corriente";
+
+type Movimiento = {
+  id: number;
+  tipo: "retiro" | "consignacion" | string;
+  monto: number;
+  fecha: string;
+  saldoAnterior: number;
+  saldoNuevo: number;
+  cuenta: TipoCuenta;
+};
+
+type Cuenta = {
+  id: TipoCuenta;
+  nombre: string;
+  saldo: number;
+  movimientos: Movimiento[];
+};
+
 type Usuario = {
   id: string;
   nombre: string;
@@ -7,17 +26,9 @@ type Usuario = {
   password: string;
   saldo: number;
   movimientos: Movimiento[];
+  cuentas: Record<TipoCuenta, Cuenta>;
   intentosFallidos: number;
   bloqueado: boolean;
-};
-
-type Movimiento = {
-  id: number;
-  tipo: "retiro" | "consignación" | string;
-  monto: number;
-  fecha: string;
-  saldoAnterior: number;
-  saldoNuevo: number;
 };
 
 type Database = {


### PR DESCRIPTION
## Summary
- restructure account data so each usuario persists ahorros/corriente balances and movements
- update the dashboard workflow to pick an active account, scope movements, and capture consignation recipients
- align the console tooling and Cliente helper with the new account-aware operations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e08be84bd083308cb301cab1a865c5